### PR TITLE
Kronecker Product of n matrices

### DIFF
--- a/src/expsolve/__init__.py
+++ b/src/expsolve/__init__.py
@@ -1,2 +1,2 @@
 from .evolve.timepropagation import solvediffeq, timegrid, order
-from .linalg.matrices import diag, matmul, batchkron
+from .linalg.matrices import diag, matmul, kron, batchkron

--- a/src/expsolve/linalg/__init__.py
+++ b/src/expsolve/linalg/__init__.py
@@ -1,1 +1,1 @@
-from .matrices import diag, matmul, batchkron
+from .matrices import diag, matmul, kron, batchkron

--- a/src/expsolve/linalg/matrices.py
+++ b/src/expsolve/linalg/matrices.py
@@ -1,5 +1,6 @@
 import torch
 from torch import complex128
+from functools import reduce
 
 
 def diag(v):
@@ -16,6 +17,10 @@ def matmul(A, v):
         return torch.matmul(A.type(complex128), u.type(complex128)).mT.reshape(shp)
     else:
         return torch.matmul(A, u).mT.reshape(shp)
+
+
+def kron(*args):
+    return reduce(torch.kron, args)
 
 
 def batchkron(A, B):


### PR DESCRIPTION
PyTorch's Kronecker product doesn't support a variable number of arguments. This function uses functool's `reduce` to apply `torch.kron` successively to a list of matrices/tensors.